### PR TITLE
WIP: Ask to uninstall if already installed

### DIFF
--- a/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
+++ b/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
@@ -65,7 +65,26 @@ FunctionEnd
 
 !define UNINST_KEY \
   "Software\Microsoft\Windows\CurrentVersion\Uninstall\%{app_name}"
+
+!macro uninstallMacro un
+  Function ${un}customUninstall
+  RMDir /r "$InstDir"
+  Delete "$SMPROGRAMS\%{app_name}.lnk"
+  DeleteRegKey /ifempty SHCTX "Software\%{app_name}"
+  DeleteRegKey SHCTX "${UNINST_KEY}"
+  FunctionEnd
+!macroend
+
+; Insert function as an installer and uninstaller function.
+!insertmacro uninstallMacro ""
+!insertmacro uninstallMacro "un."
+
+
 Section
+  ; Uninstall
+  Call customUninstall
+
+  ; Install
   SetOutPath "$InstDir"
   File /r "..\%{app_name}\*"
   WriteRegStr SHCTX "Software\%{app_name}" "" $InstDir
@@ -87,12 +106,7 @@ SectionEnd
 ;Uninstaller Section
 
 Section "Uninstall"
-
-  RMDir /r "$InstDir"
-  Delete "$SMPROGRAMS\%{app_name}.lnk"
-  DeleteRegKey /ifempty SHCTX "Software\%{app_name}"
-  DeleteRegKey SHCTX "${UNINST_KEY}"
-
+  Call un.customUninstall
 SectionEnd
 
 Function LaunchLink

--- a/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
+++ b/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
@@ -68,14 +68,10 @@ FunctionEnd
 
 !macro uninstallMacro un
   Function ${un}customUninstall
-    ReadRegStr $R0 HKLM \
-    "Software\Microsoft\Windows\CurrentVersion\Uninstall\%{app_name}" \
-    "InstallPath"
-    RMDir /r "$R0"
-
-    Delete "$SMPROGRAMS\%{app_name}.lnk"
-    DeleteRegKey /ifempty SHCTX "Software\%{app_name}"
-    DeleteRegKey SHCTX "${UNINST_KEY}"
+  RMDir /r "$InstDir"
+  Delete "$SMPROGRAMS\%{app_name}.lnk"
+  DeleteRegKey /ifempty SHCTX "Software\%{app_name}"
+  DeleteRegKey SHCTX "${UNINST_KEY}"
   FunctionEnd
 !macroend
 
@@ -94,7 +90,6 @@ Section
   WriteRegStr SHCTX "Software\%{app_name}" "" $InstDir
   WriteUninstaller "$InstDir\uninstall.exe"
   CreateShortCut "$SMPROGRAMS\%{app_name}.lnk" "$InstDir\%{app_name}.exe"
-  WriteRegStr SHCTX "${UNINST_KEY}" "InstallPath" "$InstDir"
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayName" "%{app_name}"
   WriteRegStr SHCTX "${UNINST_KEY}" "UninstallString" \
     "$\"$InstDir\uninstall.exe$\" /$MultiUser.InstallMode"

--- a/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
+++ b/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
@@ -12,6 +12,30 @@
 !include LogicLib.nsh
 
 Function .onInit
+  ReadRegStr $R0 HKLM \
+  "Software\Microsoft\Windows\CurrentVersion\Uninstall\%{app_name}" \
+  "UninstallString"
+  StrCmp $R0 "" done
+
+  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+  "%{app_name} is already installed. $\n$\nClick `OK` to remove the \
+  previous version or `Cancel` to cancel this upgrade." \
+  IDOK uninst
+  Abort
+
+  ;Run the uninstaller
+  uninst:
+    ClearErrors
+    Exec $R0
+
+    IfErrors no_remove_uninstaller done
+      ;You can either use Delete /REBOOTOK in the uninstaller or add some code
+      ;here to remove the uninstaller. Use a registry key to check
+      ;whether the user has chosen to uninstall. If you are using an uninstaller
+      ;components page, make sure all sections are uninstalled.
+    no_remove_uninstaller:
+  done:
+
   !insertmacro MULTIUSER_INIT
   ;Do not use InstallDir at all so we can detect empty $InstDir!
   ${If} $InstDir == "" ; /D not used

--- a/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
+++ b/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
@@ -68,10 +68,14 @@ FunctionEnd
 
 !macro uninstallMacro un
   Function ${un}customUninstall
-  RMDir /r "$InstDir"
-  Delete "$SMPROGRAMS\%{app_name}.lnk"
-  DeleteRegKey /ifempty SHCTX "Software\%{app_name}"
-  DeleteRegKey SHCTX "${UNINST_KEY}"
+    ReadRegStr $R0 HKLM \
+    "Software\Microsoft\Windows\CurrentVersion\Uninstall\%{app_name}" \
+    "InstallPath"
+    RMDir /r "$R0"
+
+    Delete "$SMPROGRAMS\%{app_name}.lnk"
+    DeleteRegKey /ifempty SHCTX "Software\%{app_name}"
+    DeleteRegKey SHCTX "${UNINST_KEY}"
   FunctionEnd
 !macroend
 
@@ -90,6 +94,7 @@ Section
   WriteRegStr SHCTX "Software\%{app_name}" "" $InstDir
   WriteUninstaller "$InstDir\uninstall.exe"
   CreateShortCut "$SMPROGRAMS\%{app_name}.lnk" "$InstDir\%{app_name}.exe"
+  WriteRegStr SHCTX "${UNINST_KEY}" "InstallPath" "$InstDir"
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayName" "%{app_name}"
   WriteRegStr SHCTX "${UNINST_KEY}" "UninstallString" \
     "$\"$InstDir\uninstall.exe$\" /$MultiUser.InstallMode"

--- a/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
+++ b/fbs/builtin_commands/project_template/src/main/NSIS/Installer.nsi
@@ -12,30 +12,6 @@
 !include LogicLib.nsh
 
 Function .onInit
-  ReadRegStr $R0 HKLM \
-  "Software\Microsoft\Windows\CurrentVersion\Uninstall\%{app_name}" \
-  "UninstallString"
-  StrCmp $R0 "" done
-
-  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-  "%{app_name} is already installed. $\n$\nClick `OK` to remove the \
-  previous version or `Cancel` to cancel this upgrade." \
-  IDOK uninst
-  Abort
-
-  ;Run the uninstaller
-  uninst:
-    ClearErrors
-    Exec $R0
-
-    IfErrors no_remove_uninstaller done
-      ;You can either use Delete /REBOOTOK in the uninstaller or add some code
-      ;here to remove the uninstaller. Use a registry key to check
-      ;whether the user has chosen to uninstall. If you are using an uninstaller
-      ;components page, make sure all sections are uninstalled.
-    no_remove_uninstaller:
-  done:
-
   !insertmacro MULTIUSER_INIT
   ;Do not use InstallDir at all so we can detect empty $InstDir!
   ${If} $InstDir == "" ; /D not used


### PR DESCRIPTION
I need to make sure users are uninstalling the app prior to installing a new version. I'm quite unfamiliar with NSIS and have managed to make a new window pop up on top of the installer wizard, which will ask the user to uninstall if the app is already installed. This is a very crude way to go about this, and I actually would've preferred if this step was part of the actual wizard rather than a window on top of the wizard.

I was a bit afraid that the uninstall window could appear below the regular wizard window, and I just recently received a report from a user that they mistakenly installed the app and then saw the uninstall window... so it might be possible that this could actually happen...

I guess this PR is just a starting point and something we can use to discuss this feature, as I don't feel this is polished enough to merge yet.

I got the code from here: http://nsis.sourceforge.net/Auto-uninstall_old_before_installing_new