### PR TITLE
Add support for version number in project template / startproject command

### DIFF
--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -27,6 +27,7 @@ def startproject():
         return
     app_name = _prompt_for_nonempty_value('App name (eg. MyApp): ')
     author = _prompt_for_nonempty_value('App author (eg. Joe Developer): ')
+    version = _prompt_for_nonempty_value('App initial version (eg. 1.0): ')
     mac_bundle_identifier = input(
         'Mac bundle identifier (optional, eg. com.joe.myapp): '
     )
@@ -38,6 +39,7 @@ def startproject():
         template_dir, '.', {
             'app_name': app_name,
             'author': author,
+            'version': version,
             'mac_bundle_identifier': mac_bundle_identifier
         },
         files_to_filter=[settings_file('base.json'), settings_file('mac.json')]

--- a/fbs/builtin_commands/project_template/src/build/settings/base.json
+++ b/fbs/builtin_commands/project_template/src/build/settings/base.json
@@ -1,5 +1,6 @@
 {
     "app_name": "${app_name}",
     "main_module": "src/main/python/main.py",
-    "author": "${author}"
+    "author": "${author}",
+    "version": "${version}"
 }


### PR DESCRIPTION
This resolves issue #36.

It adds support in the default project template for a version number.
It also adds a question in the `startproject` command to ask the user for an initial project version.

Example:
`>>> python -m fbs startproject`
```
App name (eg. MyApp): asdf
App author (eg. Joe Developer): qwer
App initial version (eg. 1.0): 2.3
Mac bundle identifier (optional, eg. com.joe.myapp): com.qwer.asdf
```

This results in the version number being correctly added to a frozen Mac app.
