### PR TITLE
Add Arch to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     },
     license='GPLv3 or later',
     keywords='PyQt',
-    platforms=['MacOS', 'Windows', 'Debian', 'Fedora', 'CentOS'],
+    platforms=['MacOS', 'Windows', 'Debian', 'Fedora', 'CentOS', 'Arch'],
     test_suite='tests'
 )


### PR DESCRIPTION
It is listed that `Windows, Mac and Ubuntu, Fedora and Arch Linux` are supported in this application. 

Updated setup.py to reflect this.