### PR TITLE
Add missing --debug <option> for PyInstaller

### DIFF
--- a/fbs/freeze/__init__.py
+++ b/fbs/freeze/__init__.py
@@ -37,7 +37,7 @@ def run_pyinstaller(extra_args=None, debug=False):
         path(SETTINGS['main_module'])
     ])
     if debug:
-        args.append('--debug')
+        args.extend(['--debug', 'all'])
     with _PyInstallerRuntimehook() as hook_path:
         args.extend(['--runtime-hook', hook_path])
         run(args, check=True)


### PR DESCRIPTION
The --debug flag within `freeze/__init__.py` is missing one of its required options to work.
I've added the `all` option in order to show all available information.

[PyInstaller Documentation](https://pyinstaller.readthedocs.io/en/latest/usage.html#how-to-generate)

This missing option caused an error while running `fbs freeze --debug` (on at least Windows and MacOS).

It should also fix #72 and #76.