### PR TITLE
Add support for new support module in PySide2

### DIFF
--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -39,6 +39,10 @@ def startproject():
         app = prompt_for_value('App name', default='MyApp')
     user = getuser().title()
     author = prompt_for_value('Author', default=user)
+    python_bindings = prompt_for_value('Qt bindings (PyQt5 or PySide2)', default='PyQt5')
+    while python_bindings.lower() not in ["pyqt5", "pyside2"]:
+        print('Please select between "PyQt5" or "PySide2" only')
+        python_bindings = prompt_for_value('Qt bindings (PyQt5 or PySide2)', default='PyQt5')
     eg_bundle_id = 'com.%s.%s' % (
         author.lower().split()[0], ''.join(app.lower().split())
     )
@@ -49,7 +53,6 @@ def startproject():
     mkdir('src')
     template_dir = join(dirname(__file__), 'project_template')
     template_path = lambda relpath: join(template_dir, *relpath.split('/'))
-    python_bindings = _get_python_bindings()
     copy_with_filtering(
         template_dir, '.', {
             'app_name': app,
@@ -78,7 +81,8 @@ def run():
     if not _has_module('PyQt5') and not _has_module('PySide2'):
         raise FbsError(
             "Couldn't find PyQt5 or PySide2. Maybe you need to:\n"
-            "    pip install PyQt5==5.9.2"
+            "    pip install PyQt5==5.9.2 or\n"
+            "    pip install PySide2==5.12.2"
         )
     env = dict(os.environ)
     pythonpath = path('src/main/python')

--- a/fbs/freeze/hooks/hook-shiboken2.py
+++ b/fbs/freeze/hooks/hook-shiboken2.py
@@ -1,7 +1,12 @@
 from glob import glob
 from os.path import dirname, relpath, join
 
-import shiboken2.support
+import PySide2
+
+if PySide2.__version__ == "5.12.2":
+    import PySide2.support as support
+else:
+    import shiboken2.support as support
 
 """
 This should give roughly the same results as:
@@ -15,7 +20,7 @@ The reason we don't do it this way is that it would add a dynamic link to
 PyInstaller, and thus force the GPL on fbs, preventing it from being licensed
 under different terms (such as a commercial license).
 """
-_base_dir = dirname(shiboken2.support.__file__)
+_base_dir = dirname(support.__file__)
 _python_files = glob(join(_base_dir, '**', '*.py'), recursive=True)
 _site_packages = dirname(dirname(_base_dir))
 datas = [(f, relpath(dirname(f), _site_packages)) for f in _python_files]


### PR DESCRIPTION
After the release of PySide2 5.12.2
the location of the support changed from
    shiboken2.support
to
    PySide2.support

Reference: https://codereview.qt-project.org/#/c/254525/