### PR TITLE
Update Windows 10 SDK URL

### DIFF
--- a/fbs/freeze/windows.py
+++ b/fbs/freeze/windows.py
@@ -59,7 +59,7 @@ def _add_missing_dlls():
             raise FileNotFoundError(
                 "Could not find %s on your PATH. If you are on Windows 10, you "
                 "may have to install the Windows 10 SDK from "
-                "https://dev.windows.com/en-us/downloads/windows-10-sdk. "
+                "https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk. "
                 "Otherwise, try installing KB2999226 from "
                 "https://support.microsoft.com/en-us/kb/2999226. "
                 "In both cases, add the directory containing %s to your PATH "


### PR DESCRIPTION
The current Windows 10 SDK URL redirects to a generic "Getting Started" URL: https://developer.microsoft.com/en-us/

It is possible to navigate to the SDK download page from there (Click "Windows" > "SDKS AND TOOLS" > Scroll down to "GET THE WINDOWS 10 SDK"), but there is no direct link mentioning the Windows 10 SDK on the initial page.

This PR contains the new URL linking directly to the SDK download page.