### PR TITLE
users can pass additional_hooks_dir to pyinstaller

### DIFF
--- a/fbs/freeze/__init__.py
+++ b/fbs/freeze/__init__.py
@@ -34,7 +34,11 @@ def run_pyinstaller(extra_args=None, debug=False):
         '--specpath', path('target/PyInstaller'),
         '--workpath', path('target/PyInstaller')
     ])
+
     args.extend(['--additional-hooks-dir', join(dirname(__file__), 'hooks')])
+    for hook in SETTINGS.get("additional_hooks_dir", []):
+        args.extend(["--additional-hooks-dir", hook])
+
     if debug:
         args.extend(['--debug', 'all'])
         if is_mac():


### PR DESCRIPTION
For many popular packages the hooks included with pyinstaller are sufficient, but for less prominent (or non-public) packages, custom hooks are required.

This PR allows users to specify additional directories for pyinstaller hooks in their settings files. This looks like:
```
{
...
    "additional_hooks_dir": ["some_hooks", "some_more_hooks"]
...
}
```
and causes pyinstaller to look for hooks in all listed directories in addition to `fbs/freeze/hooks`. 

Thank you for making `fbs`! Please let me know if this is the right approach to take. If so, I will go ahead and add a test.