### PR TITLE
Updating create-dmg command for macOS Catalina

### DIFF
--- a/fbs/installer/mac/__init__.py
+++ b/fbs/installer/mac/__init__.py
@@ -1,7 +1,10 @@
+import platform
 from fbs import path, SETTINGS
+from fbs_runtime.platform import is_mac
 from os import replace, remove
 from os.path import join, dirname, exists
 from subprocess import check_call, DEVNULL
+
 
 def create_installer_mac():
     app_name = SETTINGS['app_name']
@@ -11,14 +14,17 @@ def create_installer_mac():
         dest_bu = dest + '.bu'
         replace(dest, dest_bu)
     try:
-        check_call([
+        pdata = [
             join(dirname(__file__), 'create-dmg', 'create-dmg'),
             '--volname', app_name,
             '--app-drop-link', '170', '10',
             '--icon', app_name + '.app', '0', '10',
             dest,
             path('${freeze_dir}')
-        ], stdout=DEVNULL)
+        ]
+        if is_mac() and int(platform.mac_ver()[0].split('.')[1]) >= 15:
+            pdata.insert(1, '--no-internet-enable')
+        check_call(pdata, stdout=DEVNULL)
     except:
         if dest_existed:
             replace(dest_bu, dest)


### PR DESCRIPTION
As documented in #154, macOS Catalina removed the `internet-enable` verb from the `hdiutil` command used in the `create-dmg` command when running `fbs installer`. 

Here, I've created a pull request with @komodovaran's [proposed changes](https://github.com/mherrmann/fbs/issues/154#issuecomment-588967608) in that issue, incorporating @mherrmann's comments on these changes. 

(I am not entirely sure about the proper GitHub etiquette in these situations, but as I am currently blocked from creating `.dmg` files on macOS due to this issue I hope @komodovaran does not mind that I have created a pull request with their changes.)