### PR TITLE
Updates desktop file version to confirm to spec

### DIFF
--- a/fbs/_defaults/src/installer/linux/usr/share/applications/AppName.desktop
+++ b/fbs/_defaults/src/installer/linux/usr/share/applications/AppName.desktop
@@ -5,5 +5,5 @@ Exec=/opt/${app_name}/${app_name}
 Terminal=false
 NoDisplay=false
 Categories=${categories}
-Version=${version}
+Version=1.2
 Icon=${app_name}


### PR DESCRIPTION
Changes the version in the AppName.desktop file to conform to the specification as described in #202. I've tested the output of this using the desktop-file-validate tool & it passes. `desktop-file-validate` is not yet aware of version 1.3 & 1.4, so 1.2 is the most up-to-date version in wide usage to the best of my knowledge.