### PR TITLE
Allow specification of license in settings file for linux deb files

### DIFF
--- a/fbs/installer/linux.py
+++ b/fbs/installer/linux.py
@@ -54,6 +54,8 @@ def run_fpm(output_type):
         ])
     if SETTINGS['url']:
         args.extend(['--url', SETTINGS['url']])
+    if SETTINGS['license']:
+        args.extend(['--license', SETTINGS['license']])
     for dependency in SETTINGS['depends']:
         args.extend(['-d', dependency])
     if is_arch_linux():


### PR DESCRIPTION
Currently, output from `dpkg --info AppName.deb` specifies that the license of the package to be installed is unknown. This small change will allow users to specify the license in the deb file, based on a variable in a config file.

A user of fbs would add the line `"license": "GPL"` or similar in their `linux.json` to use this feature.