### PR TITLE
Update Dockerfile

### DIFF
--- a/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
+++ b/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
@@ -21,9 +21,10 @@ RUN apt-get install ruby ruby-dev build-essential -y && \
 
 WORKDIR /root/${app_name}
 
-# Set up virtual environment:
+# Set up virtual environment, upgrade pip, and install requirements:
 ADD *.txt /tmp/requirements/
 RUN python3.6 -m venv venv && \
+    venv/bin/python -m pip install --upgrade pip && \
     venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 


### PR DESCRIPTION
have had some stuff fail due to the low default pip version and needed this mod to ensure pip was upgraded before installing the requirements.

Error:
```
Step 9/17 : RUN python3.6 -m venv venv &&     venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
 ---> Running in f5dc00354e5f
Collecting PyQt5==5.15.0 (from -r /tmp/requirements/ubuntu.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/8c/90/82c62bbbadcca98e8c6fa84f1a638de1ed1c89e85368241e9cc43fcbc320/PyQt5-5.15.0.tar.gz (3.3MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python3.6/tokenize.py", line 452, in open
        buffer = _builtin_open(filename, 'rb')
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-mo1jwje0/PyQt5/setup.py'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-mo1jwje0/PyQt5/
You are using pip version 18.1, however version 20.2b1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

After this mod installs this same PyQt5 version without issues in docker which is needed alongside the PyQtWebEngine latest vs the 5.9.2 default. 
```
 fbs buildvm ubuntu
Done. You can now execute:
    fbs runvm ubuntu
(venv-fbs) [user@user-Allstar-Series:~/PycharmProjects/redacted]$ fbs runvm ubuntu
You are now in a Docker container running Ubuntu. To build your app
for this platform, use the normal commands `fbs freeze` etc.

Note that you can't launch GUIs here. So eg. `fbs run` won't work.

Another caveat is that target/ here is special: It symlinks to your
usual target/ubuntu/. So when you are done and type `exit` to leave
this container, you can find the produced binaries there.
(venv) ubuntu:redacted$ pip list installed
Package             Version
------------------- ---------
aiodns              2.0.0
altgraph            0.17
asyncio             3.4.3
bcrypt              3.1.7
boto3               1.14.22
botocore            1.17.22
certifi             2020.6.20
cffi                1.14.0
chardet             3.0.4
cryptography        2.9.2
dnspython           2.0.0
docutils            0.15.2
fbs                 0.8.7
future              0.18.2
idna                2.10
importlib-resources 3.0.0
jmespath            0.10.0
licensing           0.22
macholib            1.14
netaddr             0.8.0
paramiko            2.7.1
pefile              2019.4.18
pip                 20.1.1
pycares             3.1.1
pycparser           2.20
PyInstaller         3.4
PyNaCl              1.4.0
pyOpenSSL           19.1.0
PyQt5               5.15.0
PyQt5-sip           12.8.0
PyQt5-stubs         5.14.2.2
PyQtWebEngine       5.15.0
python-dateutil     2.8.1
requests            2.24.0
s3transfer          0.3.3
sentry-sdk          0.16.1
setuptools          40.6.2
six                 1.15.0
tornado             6.0.4
typing              3.7.4.3
urllib3             1.25.9
wheel               0.34.2
whois-alt           2.5.0
zipp                3.1.0
(venv) ubuntu:redacted$
```


**Please Note: The same mod might also be needed in the other linux os docker files to ensure its always using the latest pip.**