### PR TITLE
Update __init__.py

### DIFF
--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -402,14 +402,17 @@ def upload():
     _LOG.info(message, extra=extra)
 
 @command
-def release():
+def release(release_version):
     """
     Bump version and run clean,freeze,...,upload
     """
     require_existing_project()
     version = SETTINGS['version']
     next_version = _get_next_version(version)
-    release_version = prompt_for_value('Release version', default=next_version)
+    if release_version == 'bump':
+        release_version = prompt_for_value('Release version', default=next_version)
+    elif release_version == 'current':
+        release_version = SETTINGS['version']
     activate_profile('release')
     SETTINGS['version'] = release_version
     log_level = _LOG.level


### PR DESCRIPTION
Update to make bumping the version explicit and to allow using the current version for the release version based on whether 'bump' or 'current' is used as an argument.

In an ideal world it would allow an optional argument if specified to be passed to the release_version and skip the bump release stuff.

As it would not let me do that or use Booleans for optional stuff i think this is the best approach i could think of.

Example:
```
(venv-fbs) []$ fbs release current
Doing `require 'backports'` is deprecated and will not load any backport in the next major release.
Require just the needed backports instead, or 'backports/latest'.
^C
(venv-fbs) []$
```
```
(venv-fbs) []$ fbs release bump
Release version [1.0.34] : ^C
(venv-fbs) []$
```

This is to fix https://github.com/mherrmann/fbs/issues/211

The only downside is that the documentation should be updated to include that "bump" or "current" should be called when calling release now to explicitly state to use current or increase version and suggest or let the user provide a custom version for the release.