### PR TITLE
Allow additional pyinstaller args when calling `freeze`.

### DIFF
--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -96,7 +96,7 @@ def run():
     subprocess.run([sys.executable, path(SETTINGS['main_module'])], env=env)
 
 @command
-def freeze(debug=False):
+def freeze(*args, debug=False):
     """
     Compile your code to a standalone executable
     """
@@ -106,32 +106,35 @@ def freeze(debug=False):
             "Could not find PyInstaller. Maybe you need to:\n"
             "    pip install PyInstaller==3.4"
         )
+    # additional user pyinstaller args
+    args = [(arg.split('=', 1)[0], arg.split('=', 1)[1]) for arg in args]
+    
     # Import respective functions late to avoid circular import
     # fbs <-> fbs.freeze.X.
     app_name = SETTINGS['app_name']
     if is_mac():
         from fbs.freeze.mac import freeze_mac
-        freeze_mac(debug=debug)
+        freeze_mac(args, debug=debug)
         executable = 'target/%s.app/Contents/MacOS/%s' % (app_name, app_name)
     else:
         executable = join('target', app_name, app_name)
         if is_windows():
             from fbs.freeze.windows import freeze_windows
-            freeze_windows(debug=debug)
+            freeze_windows(args, debug=debug)
             executable += '.exe'
         elif is_linux():
             if is_ubuntu():
                 from fbs.freeze.ubuntu import freeze_ubuntu
-                freeze_ubuntu(debug=debug)
+                freeze_ubuntu(args)
             elif is_arch_linux():
                 from fbs.freeze.arch import freeze_arch
-                freeze_arch(debug=debug)
+                freeze_arch(args)
             elif is_fedora():
                 from fbs.freeze.fedora import freeze_fedora
-                freeze_fedora(debug=debug)
+                freeze_fedora(args)
             else:
                 from fbs.freeze.linux import freeze_linux
-                freeze_linux(debug=debug)
+                freeze_linux(args)
         else:
             raise FbsError('Unsupported OS')
     _LOG.info(

--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -106,21 +106,32 @@ def freeze(*args, debug=False):
             "Could not find PyInstaller. Maybe you need to:\n"
             "    pip install PyInstaller==3.4"
         )
+    
     # additional user pyinstaller args
-    args = [(arg.split('=', 1)[0], arg.split('=', 1)[1]) for arg in args]
+    additional_args = []
+    for arg in args:
+        try:
+            k, v = arg.split('=', 1)
+            additional_args.append(k)
+            additional_args.append(v)
+            
+        except ValueError:
+            additional_args.append(arg)
+            
+    print(additional_args)
     
     # Import respective functions late to avoid circular import
     # fbs <-> fbs.freeze.X.
     app_name = SETTINGS['app_name']
     if is_mac():
         from fbs.freeze.mac import freeze_mac
-        freeze_mac(args, debug=debug)
+        freeze_mac(additional_args, debug=debug)
         executable = 'target/%s.app/Contents/MacOS/%s' % (app_name, app_name)
     else:
         executable = join('target', app_name, app_name)
         if is_windows():
             from fbs.freeze.windows import freeze_windows
-            freeze_windows(args, debug=debug)
+            freeze_windows(additional_args, debug=debug)
             executable += '.exe'
         elif is_linux():
             if is_ubuntu():

--- a/fbs/freeze/mac.py
+++ b/fbs/freeze/mac.py
@@ -6,11 +6,11 @@ from os.path import exists
 from shutil import copy, rmtree
 from subprocess import run
 
-def freeze_mac(debug=False):
+def freeze_mac(args, debug=False):
     if not exists(path('target/Icon.icns')):
         _generate_iconset()
         run(['iconutil', '-c', 'icns', path('target/Icon.iconset')], check=True)
-    args = []
+
     if not (debug or SETTINGS['show_console_window']):
         args.append('--windowed')
     args.extend(['--icon', path('target/Icon.icns')])

--- a/fbs/freeze/windows.py
+++ b/fbs/freeze/windows.py
@@ -8,8 +8,7 @@ import os
 import struct
 import sys
 
-def freeze_windows(debug=False):
-    args = []
+def freeze_windows(args, debug=False):
     if not (debug or SETTINGS['show_console_window']):
         # The --windowed flag below prevents us from seeing any console output.
         # We therefore only add it when we're not debugging.


### PR DESCRIPTION
Allows for any number of additional pyinstaller arguments to be passed to `freeze`, which in turns passes the arguments to `freeze_mac` and `freeze_windows`. Arguments can be flags or flag value pairs.

Examples:
``` cmd
>freeze --version-file=file_version_info.py --uac-uiaccess
```

``` python
def freeze():
    fbs.cmdline.main()
    fbs.builtin_commands.freeze('--version-file=file_version_info.py')
```