### PR TITLE
Fix windows release failing due to repo() and upload() being called.

### DIFF
--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -429,12 +429,15 @@ def release(version=None):
             sign()
         installer()
         if (is_windows() and _has_windows_codesigning_certificate()) or \
-            is_arch_linux() or is_fedora():
+            is_arch_linux() or is_fedora() or is_ubuntu():
             sign_installer()
-        repo()
+        # Only want to try to repo/upload when its NOT windows.
+        if is_arch_linux() or is_fedora() or is_ubuntu():
+            repo()
     finally:
         _LOG.setLevel(log_level)
-    upload()
+    if is_arch_linux() or is_fedora() or is_ubuntu():    
+        upload()
     base_json = 'src/build/settings/base.json'
     update_json(path(base_json), { 'version': release_version })
     _LOG.info('Also, %s was updated with the new version.', base_json)

--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -429,7 +429,7 @@ def release(version=None):
             sign()
         installer()
         if (is_windows() and _has_windows_codesigning_certificate()) or \
-            is_arch_linux() or is_fedora() or is_ubuntu():
+            is_arch_linux() or is_fedora():
             sign_installer()
         # Only want to try to repo/upload when its NOT windows.
         if is_arch_linux() or is_fedora() or is_ubuntu():


### PR DESCRIPTION
This will fix the case where due to repo not being an action for windows releases that it fails with the below error.

Also noticed it looks like its not trying to sign installer for ubuntu so added that but if thats invalid feel free to ignore that change

```
(.venv) C:\Users\mike\PycharmProjects\wizard-assistant-new>fbs release current
This command is not supported on this platform.

(.venv) C:\Users\mike\PycharmProjects\wizard-assistant-new>
```