### PR TITLE
User configurable python version to use inside docker containers and more

### DIFF
--- a/fbs/_defaults/src/build/docker/arch/Dockerfile
+++ b/fbs/_defaults/src/build/docker/arch/Dockerfile
@@ -17,7 +17,7 @@ RUN echo 'Server=https://mirror.rackspace.com/archlinux/$repo/os/$arch' > /etc/p
 RUN pacman -S --noconfirm base-devel openssl zlib xz git
 
 # Install base system libraries additionally specified by user.
-ENV USER_OS_DEPENDS /tmp/requirements/base_os_dependencies.txt
+ENV USER_OS_DEPENDS /tmp/requirements/os_dependencies_${requirements}
 RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then  \
     pacman -S --noconfirm $(cat "${USER_OS_DEPENDS}"); fi ||True
 
@@ -29,11 +29,15 @@ ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 # Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
 ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
 
-# Set default python version to file if provided and trim any whitepace.
+# Set default python version to global file ".python-version.txt" or distro specific if .python-version_arch.txt
 ENV DEFAULT_PYTHON_VERSION 3.6.12
 ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
-RUN if [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
-    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE}"; else \
+ENV PYTHON_VERSION_FILE_DISTRO /tmp/requirements/.python-version_${requirements}
+RUN if  [ -f "${PYTHON_VERSION_FILE_DISTRO}" ] && [ -s "${PYTHON_VERSION_FILE_DISTRO}" ] ; then \
+    echo "DISTRO PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}"; \
+    cp -f "${PYTHON_VERSION_FILE_DISTRO}" "${PYTHON_VERSION_FILE}"; \
+    elif  [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
+    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}" ; else \
     echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
 
 # Install pyenv

--- a/fbs/_defaults/src/build/docker/arch/Dockerfile
+++ b/fbs/_defaults/src/build/docker/arch/Dockerfile
@@ -1,28 +1,59 @@
 # Build on an old Arch version on purpose, to maximize compatibility:
 FROM fmanbuildsystem/archlinux:2018.04.01
 
+# Alternatively Build on an latest Arch version on purpose, to maximize compatibility as its rolling release:
+# FROM library/archlinux:latest
+
 ARG requirements
-
-RUN echo 'Server=https://archive.archlinux.org/repos/2018/04/01/$repo/os/$arch' > /etc/pacman.d/mirrorlist && \
-    pacman -Syy
-
-# Python 3.6:
-RUN pacman -S --noconfirm python
-
-# fpm:
-RUN pacman -S --noconfirm ruby ruby-rdoc && \
-    export PATH=$PATH:$(ruby -e "puts Gem.user_dir")/bin && \
-    gem update && \
-    gem install --no-ri --no-rdoc fpm
 
 WORKDIR /root/${app_name}
 
-# Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python -m venv venv && \
-    venv/bin/python -m pip install --upgrade pip && \ 
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
-RUN rm -rf /tmp/requirements/
+
+RUN echo 'Server=https://mirror.rackspace.com/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist && \
+    pacman -Syy
+
+# Set of all dependencies needed for pyenv and building a PyQt5 app with PyInstaller to work on
+RUN pacman -S --noconfirm base-devel openssl zlib xz git
+
+# Install base system libraries additionally specified by user.
+ENV USER_OS_DEPENDS /tmp/requirements/base_os_dependencies.txt
+RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then  \
+    pacman -S --noconfirm $(cat "${USER_OS_DEPENDS}"); fi ||True
+
+
+# Set-up necessary Env vars for PyEnv
+ENV PYENV_ROOT /root/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
+ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
+
+# Set default python version to file if provided and trim any whitepace.
+ENV DEFAULT_PYTHON_VERSION 3.6.12
+ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
+RUN if [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
+    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE}"; else \
+    echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
+
+# Install pyenv
+RUN set -ex \
+    && PYTHON_VERSION=$(cat /tmp/requirements/.python-version.txt | sed -e 's/^[[:space:]]*//') && cd "${HOME}" \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install "${PYTHON_VERSION}" \
+    && pyenv global "${PYTHON_VERSION}" \
+    && pyenv rehash
+
+
+# https://python-docs.readthedocs.io/en/latest/writing/gotchas.html
+ENV PYTHONDONTWRITEBYTECODE true
+
+# fpm: Set fallbacks for --no-document when later ruby is used which fails due to --no-ri --no-rdoc no longer existing
+RUN pacman -S --noconfirm ruby ruby-rdoc && \
+    export PATH=$PATH:$(ruby -e "puts Gem.user_dir")/bin && \
+    gem update && \
+    gem install --no-document fpm||gem install --no-document fpm
 
 # Welcome message, displayed by ~/.bashrc:
 ADD motd /etc/motd

--- a/fbs/_defaults/src/build/docker/arch/Dockerfile
+++ b/fbs/_defaults/src/build/docker/arch/Dockerfile
@@ -1,4 +1,3 @@
-# Build on an old Arch version on purpose, to maximize compatibility:
 FROM fmanbuildsystem/archlinux:2018.04.01
 
 # Alternatively Build on an latest Arch version on purpose, to maximize compatibility as its rolling release:
@@ -6,52 +5,28 @@ FROM fmanbuildsystem/archlinux:2018.04.01
 
 ARG requirements
 
-WORKDIR /root/${app_name}
-
-ADD *.txt /tmp/requirements/
+ARG python_version=3.6.12
+ARG python_build_deps="base-devel openssl zlib xz git"
 
 RUN echo 'Server=https://mirror.rackspace.com/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist && \
     pacman -Syy
 
-# Set of all dependencies needed for pyenv and building a PyQt5 app with PyInstaller to work on
-RUN pacman -S --noconfirm base-devel openssl zlib xz git
-
-# Install base system libraries additionally specified by user.
-ENV USER_OS_DEPENDS /tmp/requirements/os_dependencies_${requirements}
-RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then  \
-    pacman -S --noconfirm $(cat "${USER_OS_DEPENDS}"); fi ||True
-
-
-# Set-up necessary Env vars for PyEnv
+# Install pyenv:
+RUN pacman -S --noconfirm curl git
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-
-# Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
-ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
-
-# Set default python version to global file ".python-version.txt" or distro specific if .python-version_arch.txt
-ENV DEFAULT_PYTHON_VERSION 3.6.12
-ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
-ENV PYTHON_VERSION_FILE_DISTRO /tmp/requirements/.python-version_${requirements}
-RUN if  [ -f "${PYTHON_VERSION_FILE_DISTRO}" ] && [ -s "${PYTHON_VERSION_FILE_DISTRO}" ] ; then \
-    echo "DISTRO PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}"; \
-    cp -f "${PYTHON_VERSION_FILE_DISTRO}" "${PYTHON_VERSION_FILE}"; \
-    elif  [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
-    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}" ; else \
-    echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
-
-# Install pyenv
-RUN set -ex \
-    && PYTHON_VERSION=$(cat /tmp/requirements/.python-version.txt | sed -e 's/^[[:space:]]*//') && cd "${HOME}" \
-    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && pyenv update \
-    && pyenv install "${PYTHON_VERSION}" \
-    && pyenv global "${PYTHON_VERSION}" \
-    && pyenv rehash
-
+RUN curl https://pyenv.run | bash
+RUN pyenv update
 
 # https://python-docs.readthedocs.io/en/latest/writing/gotchas.html
 ENV PYTHONDONTWRITEBYTECODE true
+
+# Install Python:
+RUN echo $python_build_deps | xargs pacman -S --noconfirm
+RUN CONFIGURE_OPTS=--enable-shared pyenv install $python_version && \
+    pyenv global $python_version && \
+    pyenv rehash
+
 
 # fpm: Set fallbacks for --no-document when later ruby is used which fails due to --no-ri --no-rdoc no longer existing
 RUN pacman -S --noconfirm ruby ruby-rdoc && \
@@ -59,15 +34,13 @@ RUN pacman -S --noconfirm ruby ruby-rdoc && \
     gem update && \
     gem install --no-document fpm||gem install --no-document fpm
 
+WORKDIR /root/${app_name}
+
+# Set up virtual environment, upgrade pip, and install requirements:
+ADD *.txt /tmp/requirements/
+RUN pip install --upgrade pip && \
+    pip install -r "/tmp/requirements/${requirements}"
+RUN rm -rf /tmp/requirements/
+
 # Welcome message, displayed by ~/.bashrc:
 ADD motd /etc/motd
-
-ADD .bashrc /root/.bashrc
-
-# Import GPG key for code signing the installer:
-ADD private-key.gpg public-key.gpg /tmp/
-RUN gpg -q --batch --yes --passphrase ${gpg_pass} --import /tmp/private-key.gpg /tmp/public-key.gpg && \
-    rm /tmp/private-key.gpg /tmp/public-key.gpg
-
-ADD gpg-agent.conf /root/.gnupg/gpg-agent.conf
-RUN gpgconf --kill gpg-agent

--- a/fbs/_defaults/src/build/docker/arch/Dockerfile
+++ b/fbs/_defaults/src/build/docker/arch/Dockerfile
@@ -44,3 +44,13 @@ RUN rm -rf /tmp/requirements/
 
 # Welcome message, displayed by ~/.bashrc:
 ADD motd /etc/motd
+
+ADD .bashrc /root/.bashrc
+
+# Import GPG key for code signing the installer:
+ADD private-key.gpg public-key.gpg /tmp/
+RUN gpg -q --batch --yes --passphrase ${gpg_pass} --import /tmp/private-key.gpg /tmp/public-key.gpg && \
+    rm /tmp/private-key.gpg /tmp/public-key.gpg
+
+ADD gpg-agent.conf /root/.gnupg/gpg-agent.conf
+RUN gpgconf --kill gpg-agent

--- a/fbs/_defaults/src/build/docker/fedora/Dockerfile
+++ b/fbs/_defaults/src/build/docker/fedora/Dockerfile
@@ -3,69 +3,47 @@ FROM fmanbuildsystem/fedora:25
 
 ARG requirements
 
-WORKDIR /root/${app_name}
+ARG python_version=3.6.12
+ARG python_build_deps="libstdc++ freetype binutils git findutils"
 
-ADD *.txt /tmp/requirements/
+# Updates:
+RUN dnf -y update && dnf clean all
 
-# Absolute minimum requirements for building a PyQt5 app with PyInstaller:
-RUN dnf -y update && \
-        dnf install -y libstdc++ freetype binutils git findutils && \
-        dnf clean all
-
-# Install base system libraries additionally specified by user.
-ENV USER_OS_DEPENDS /tmp/requirements/os_dependencies_${requirements}
-RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then dnf upgrade -y && \
-    dnf install -y $(cat "${USER_OS_DEPENDS}") && \
-    dnf clean all; fi ||True
-
-
+# Install pyenv:
 # Pyenv minimum requirements : https://github.com/pyenv/pyenv/wiki#suggested-build-environment
-RUN dnf install -y make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel \
+RUN dnf install -y curl git make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel \
     libffi-devel xz
-
-# Set-up necessary Env vars for PyEnv
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-
-# Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
-ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
-
-# Set default python version to global file ".python-version.txt" or distro specific if .python-version_fedora.txt
-ENV DEFAULT_PYTHON_VERSION 3.6.12
-ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
-ENV PYTHON_VERSION_FILE_DISTRO /tmp/requirements/.python-version_${requirements}
-RUN if  [ -f "${PYTHON_VERSION_FILE_DISTRO}" ] && [ -s "${PYTHON_VERSION_FILE_DISTRO}" ] ; then \
-    echo "DISTRO PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}"; \
-    cp -f "${PYTHON_VERSION_FILE_DISTRO}" "${PYTHON_VERSION_FILE}"; \
-    elif  [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
-    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}" ; else \
-    echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
-
-# Install pyenv
-RUN set -ex \
-    && PYTHON_VERSION=$(cat /tmp/requirements/.python-version.txt | sed -e 's/^[[:space:]]*//') && cd "${HOME}" \
-    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && pyenv update \
-    && pyenv install "${PYTHON_VERSION}" \
-    && pyenv global "${PYTHON_VERSION}" \
-    && pyenv rehash
-
+RUN curl https://pyenv.run | bash
+RUN pyenv update
 
 # https://python-docs.readthedocs.io/en/latest/writing/gotchas.html
 ENV PYTHONDONTWRITEBYTECODE true
+
+# Install Python:
+RUN echo $python_build_deps | xargs dnf install -y
+RUN CONFIGURE_OPTS=--enable-shared pyenv install $python_version && \
+    pyenv global $python_version && \
+    pyenv rehash
+
 
 # fpm: Set fallbacks for --no-document when later ruby is used which fails due to --no-ri --no-rdoc no longer existing
 RUN dnf install -y ruby-devel gcc make rpm-build libffi-devel && \
     gem install --no-ri --no-rdoc fpm||gem install --no-document fpm
 
-# Upgrade pip and install Python pip packages needed:
-RUN pip install --upgrade pip && pip install -r "/tmp/requirements/${requirements}"
+WORKDIR /root/${app_name}
+
+# Set up virtual environment, upgrade pip, and install requirements:
+ADD *.txt /tmp/requirements/
+RUN pip install --upgrade pip && \
+    pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 # Welcome message, displayed by ~/.bashrc:
 ADD motd /etc/motd
 
-ADD .bashrc /root
+ADD .bashrc /root/.bashrc
 
 ADD gpg-agent.conf /root/.gnupg/gpg-agent.conf
 RUN chmod -R 600 /root/.gnupg

--- a/fbs/_defaults/src/build/docker/fedora/Dockerfile
+++ b/fbs/_defaults/src/build/docker/fedora/Dockerfile
@@ -13,9 +13,9 @@ RUN dnf -y update && \
         dnf clean all
 
 # Install base system libraries additionally specified by user.
-ENV USER_OS_DEPENDS /tmp/requirements/base_os_dependencies.txt
+ENV USER_OS_DEPENDS /tmp/requirements/os_dependencies_${requirements}
 RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then dnf upgrade -y && \
-    dnf install -y $(cat /tmp/requirements/base_os_dependencies.txt) && \
+    dnf install -y $(cat "${USER_OS_DEPENDS}") && \
     dnf clean all; fi ||True
 
 
@@ -30,11 +30,15 @@ ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 # Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
 ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
 
-# Set default python version to file if provided and trim any whitepace.
+# Set default python version to global file ".python-version.txt" or distro specific if .python-version_fedora.txt
 ENV DEFAULT_PYTHON_VERSION 3.6.12
 ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
-RUN if [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
-    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE}"; else \
+ENV PYTHON_VERSION_FILE_DISTRO /tmp/requirements/.python-version_${requirements}
+RUN if  [ -f "${PYTHON_VERSION_FILE_DISTRO}" ] && [ -s "${PYTHON_VERSION_FILE_DISTRO}" ] ; then \
+    echo "DISTRO PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}"; \
+    cp -f "${PYTHON_VERSION_FILE_DISTRO}" "${PYTHON_VERSION_FILE}"; \
+    elif  [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
+    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}" ; else \
     echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
 
 # Install pyenv

--- a/fbs/_defaults/src/build/docker/fedora/Dockerfile
+++ b/fbs/_defaults/src/build/docker/fedora/Dockerfile
@@ -3,23 +3,59 @@ FROM fmanbuildsystem/fedora:25
 
 ARG requirements
 
-# Python 3.6:
-RUN dnf install -y python36
-
-# Absolute minimum requirements for building a PyQt5 app with PyInstaller:
-RUN dnf install -y libstdc++ freetype binutils
-
-# fpm:
-RUN dnf install -y ruby-devel gcc make rpm-build libffi-devel && \
-    gem install --no-ri --no-rdoc fpm
-
 WORKDIR /root/${app_name}
 
-# Set up virtual environment:
 ADD *.txt /tmp/requirements/
-RUN python3.6 -m venv venv && \
-    venv/bin/python -m pip install --upgrade pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+
+# Absolute minimum requirements for building a PyQt5 app with PyInstaller:
+RUN dnf -y update && \
+        dnf install -y libstdc++ freetype binutils git findutils && \
+        dnf clean all
+
+# Install base system libraries additionally specified by user.
+ENV USER_OS_DEPENDS /tmp/requirements/base_os_dependencies.txt
+RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then dnf upgrade -y && \
+    dnf install -y $(cat /tmp/requirements/base_os_dependencies.txt) && \
+    dnf clean all; fi ||True
+
+
+# Pyenv minimum requirements : https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+RUN dnf install -y make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel \
+    libffi-devel xz
+
+# Set-up necessary Env vars for PyEnv
+ENV PYENV_ROOT /root/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
+ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
+
+# Set default python version to file if provided and trim any whitepace.
+ENV DEFAULT_PYTHON_VERSION 3.6.12
+ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
+RUN if [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
+    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE}"; else \
+    echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
+
+# Install pyenv
+RUN set -ex \
+    && PYTHON_VERSION=$(cat /tmp/requirements/.python-version.txt | sed -e 's/^[[:space:]]*//') && cd "${HOME}" \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install "${PYTHON_VERSION}" \
+    && pyenv global "${PYTHON_VERSION}" \
+    && pyenv rehash
+
+
+# https://python-docs.readthedocs.io/en/latest/writing/gotchas.html
+ENV PYTHONDONTWRITEBYTECODE true
+
+# fpm: Set fallbacks for --no-document when later ruby is used which fails due to --no-ri --no-rdoc no longer existing
+RUN dnf install -y ruby-devel gcc make rpm-build libffi-devel && \
+    gem install --no-ri --no-rdoc fpm||gem install --no-document fpm
+
+# Upgrade pip and install Python pip packages needed:
+RUN pip install --upgrade pip && pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 # Welcome message, displayed by ~/.bashrc:

--- a/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
+++ b/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
@@ -1,67 +1,40 @@
 # Build on an old Ubuntu version on purpose, to maximize compatibility:
-FROM fmanbuildsystem/ubuntu:16.04
-
+FROM ubuntu:16.04
 
 ARG requirements
 
-WORKDIR /root/${app_name}
+ARG python_version=3.6.12
+ARG python_build_deps="build-essential libssl-dev zlib1g-dev libncurses5-dev libreadline-dev libgdbm-dev libdb5.3-dev libbz2-dev liblzma-dev libsqlite3-dev libffi-dev tcl-dev tk tk-dev"
 
-ADD *.txt /tmp/requirements/
+RUN apt-get update && \
+    apt-get upgrade -y
 
-# Set of all dependencies needed for pyenv and building a PyQt5 app with PyInstaller to work on Ubuntu
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y \
-        && apt-get install -y --no-install-recommends software-properties-common ca-certificates make build-essential \
-        libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev \
-        libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev mecab-ipadic-utf8 git
+# Install pyenv:
+RUN apt-get install -y curl git
+ENV PYENV_ROOT /root/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+RUN curl https://pyenv.run | bash
+RUN pyenv update
 
-# Install base system libraries additionally specified by user.
-ENV USER_OS_DEPENDS /tmp/requirements/os_dependencies_${requirements}
-RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then apt-get update && \
-    apt-get install -y $(cat "${USER_OS_DEPENDS}") && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/dpkg/dpkg.cfg.d/02apt-speedup; fi ||True
+# Install Python:
+RUN echo $python_build_deps | xargs apt-get install -y --no-install-recommends
+RUN CONFIGURE_OPTS=--enable-shared pyenv install $python_version && \
+    pyenv global $python_version && \
+    pyenv rehash
 
 # Add missing file libGL.so.1 for PyQt5.QtGui:
 RUN apt-get install libgl1-mesa-glx -y
 
-# Set-up necessary Env vars for PyEnv
-ENV PYENV_ROOT /root/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-
-# Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
-ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
-
-# Set default python version to global file ".python-version.txt" or distro specific if .python-version_ubuntu.txt
-ENV DEFAULT_PYTHON_VERSION 3.6.12
-ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
-ENV PYTHON_VERSION_FILE_DISTRO /tmp/requirements/.python-version_${requirements}
-RUN if  [ -f "${PYTHON_VERSION_FILE_DISTRO}" ] && [ -s "${PYTHON_VERSION_FILE_DISTRO}" ] ; then \
-    echo "DISTRO PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}"; \
-    cp -f "${PYTHON_VERSION_FILE_DISTRO}" "${PYTHON_VERSION_FILE}"; \
-    elif  [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
-    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}" ; else \
-    echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
-
-# Install pyenv
-RUN set -ex \
-    && PYTHON_VERSION=$(cat /tmp/requirements/.python-version.txt | sed -e 's/^[[:space:]]*//') && cd "${HOME}" \
-    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && pyenv update \
-    && pyenv install "${PYTHON_VERSION}" \
-    && pyenv global "${PYTHON_VERSION}" \
-    && pyenv rehash
-
-
-# https://python-docs.readthedocs.io/en/latest/writing/gotchas.html
-ENV PYTHONDONTWRITEBYTECODE true
-
-# fpm: Set fallbacks for --no-document when later ruby is used which fails due to --no-ri --no-rdoc no longer existing
+# fpm:
 RUN apt-get install ruby ruby-dev build-essential -y && \
-    gem install --no-ri --no-rdoc fpm||gem install --no-document fpm
+    gem install --no-document fpm
 
-# Upgrade pip and install Python pip packages needed:
-RUN pip install --upgrade pip && pip install -r "/tmp/requirements/${requirements}"
+WORKDIR /root/${app_name}
+
+# Set up virtual environment, upgrade pip, and install requirements:
+ADD *.txt /tmp/requirements/
+RUN pip install --upgrade pip && \
+    pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 # Welcome message, displayed by ~/.bashrc:

--- a/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
+++ b/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get upgrade -y \
         libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev mecab-ipadic-utf8 git
 
 # Install base system libraries additionally specified by user.
-ENV USER_OS_DEPENDS /tmp/requirements/base_os_dependencies.txt
+ENV USER_OS_DEPENDS /tmp/requirements/os_dependencies_${requirements}
 RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then apt-get update && \
     apt-get install -y $(cat "${USER_OS_DEPENDS}") && \
     apt-get clean && \
@@ -32,11 +32,15 @@ ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 # Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
 ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
 
-# Set default python version to file if provided and trim any whitepace.
+# Set default python version to global file ".python-version.txt" or distro specific if .python-version_ubuntu.txt
 ENV DEFAULT_PYTHON_VERSION 3.6.12
 ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
-RUN if [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
-    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE}"; else \
+ENV PYTHON_VERSION_FILE_DISTRO /tmp/requirements/.python-version_${requirements}
+RUN if  [ -f "${PYTHON_VERSION_FILE_DISTRO}" ] && [ -s "${PYTHON_VERSION_FILE_DISTRO}" ] ; then \
+    echo "DISTRO PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}"; \
+    cp -f "${PYTHON_VERSION_FILE_DISTRO}" "${PYTHON_VERSION_FILE}"; \
+    elif  [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
+    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE_DISTRO}" ; else \
     echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
 
 # Install pyenv

--- a/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
+++ b/fbs/_defaults/src/build/docker/ubuntu/Dockerfile
@@ -1,31 +1,63 @@
 # Build on an old Ubuntu version on purpose, to maximize compatibility:
 FROM fmanbuildsystem/ubuntu:16.04
 
+
 ARG requirements
 
-RUN apt-get update && \
-    apt-get upgrade -y
+WORKDIR /root/${app_name}
 
-# Python 3.6:
-RUN DEBIAN_FRONTEND=noninteractive apt-get install software-properties-common -y && \
-    add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt-get update && \
-    apt-get install python3.6 python3.6-dev python3.6-venv -y
+ADD *.txt /tmp/requirements/
+
+# Set of all dependencies needed for pyenv and building a PyQt5 app with PyInstaller to work on Ubuntu
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y \
+        && apt-get install -y --no-install-recommends software-properties-common ca-certificates make build-essential \
+        libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev \
+        libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev mecab-ipadic-utf8 git
+
+# Install base system libraries additionally specified by user.
+ENV USER_OS_DEPENDS /tmp/requirements/base_os_dependencies.txt
+RUN if [ -f "${USER_OS_DEPENDS}" ] && [ -s "${USER_OS_DEPENDS}" ] ; then apt-get update && \
+    apt-get install -y $(cat "${USER_OS_DEPENDS}") && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/dpkg/dpkg.cfg.d/02apt-speedup; fi ||True
 
 # Add missing file libGL.so.1 for PyQt5.QtGui:
 RUN apt-get install libgl1-mesa-glx -y
 
-# fpm:
+# Set-up necessary Env vars for PyEnv
+ENV PYENV_ROOT /root/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Reference: https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared
+ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
+
+# Set default python version to file if provided and trim any whitepace.
+ENV DEFAULT_PYTHON_VERSION 3.6.12
+ENV PYTHON_VERSION_FILE /tmp/requirements/.python-version.txt
+RUN if [ -f "${PYTHON_VERSION_FILE}" ] && [ -s "${PYTHON_VERSION_FILE}" ] ; then \
+    echo "Existing PYTHON VERSION File found: ${PYTHON_VERSION_FILE}"; else \
+    echo "${DEFAULT_PYTHON_VERSION}" > "${PYTHON_VERSION_FILE}" ; fi
+
+# Install pyenv
+RUN set -ex \
+    && PYTHON_VERSION=$(cat /tmp/requirements/.python-version.txt | sed -e 's/^[[:space:]]*//') && cd "${HOME}" \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && pyenv update \
+    && pyenv install "${PYTHON_VERSION}" \
+    && pyenv global "${PYTHON_VERSION}" \
+    && pyenv rehash
+
+
+# https://python-docs.readthedocs.io/en/latest/writing/gotchas.html
+ENV PYTHONDONTWRITEBYTECODE true
+
+# fpm: Set fallbacks for --no-document when later ruby is used which fails due to --no-ri --no-rdoc no longer existing
 RUN apt-get install ruby ruby-dev build-essential -y && \
-    gem install --no-ri --no-rdoc fpm
+    gem install --no-ri --no-rdoc fpm||gem install --no-document fpm
 
-WORKDIR /root/${app_name}
-
-# Set up virtual environment, upgrade pip, and install requirements:
-ADD *.txt /tmp/requirements/
-RUN python3.6 -m venv venv && \
-    venv/bin/python -m pip install --upgrade pip && \
-    venv/bin/python -m pip install -r "/tmp/requirements/${requirements}"
+# Upgrade pip and install Python pip packages needed:
+RUN pip install --upgrade pip && pip install -r "/tmp/requirements/${requirements}"
 RUN rm -rf /tmp/requirements/
 
 # Welcome message, displayed by ~/.bashrc:


### PR DESCRIPTION
Was setting up a new project the other day with fbs and when trying to run the default buildvm for all 3 OS's i noticed a number of issues. most notably that there were timeouts for some repos and curl/openssl issues and previous ones didn't always install or update before attempting stuff.

I have first off switched all docker builds file to install python via pyenv which works universally the same way across all Linux OS's and also provides the added benefit allowing you to pick a specific python version not just the major ones. So if you know your dependencies require 3.6.8 on one distro but there's bugs with that version in others your stuck trying to manually edit the docker templates everytime pip updates fbs and reverts your changes.

This leaves the current stuff working, but adds the ability for a user to override and set ANY python version they want and it just works no tinkering with pip installed fbs docker files/templates. 

To do this all that needs done is to create a file named `.python-version.txt` in the requirements/ folder like `requirements/.python-version.txt` and if it exists that will override the default fbs 3.6.12 version that would be set in the absence of that file. That would set the desired python version for all docker images to the same value. 

![image](https://user-images.githubusercontent.com/1596188/113530134-44af4380-9593-11eb-8a8d-b6293c328f90.png)

If you need the ability to selectively override based on the distro that also works too and leverages the existing stuff that templates the docker files so you can just drop a file like `.python-version_ubuntu.txt` if it were for ubunutu and it would supersede both the user global requirements/.python-version.txt and the default FBS version.



But wait there's more.....
So in the same way you can optionally add pip requirements via the requirements/${arch}.txt

You can also add any extra rpm/deb/aur packages installed by the package manager that also are needed into a distro specific file like this if it were for arch `requirements/os_dependencies_arch.txt` 
![image](https://user-images.githubusercontent.com/1596188/113530499-344b9880-9594-11eb-8d5c-053457815ff0.png)



This augments the existing stuff without breaking anything and should make maintenance easier on both fbs and the people using it who like me are tired of having to edit source code alot in situations like this while leaving it super simple to use for those that don't need these optional things.

Parting thoughts
Is this the best way to implement this? maybe not but its a valid working Proof of concept that is not super hard to use and requires no effort(New code to be written) on @mherrmann besides merging it in. :smile: 

I was looking at the other stuff like maybe adding it to fbs/_defaults/src/build/settings/base.json but as filtering already replaces all `${requirements}` with  `ubuntu.txt` I just leverage that way things are future proof if more distros are added.

https://github.com/mherrmann/fbs/blob/236d82fcecea40345c30a347b2a2c3f8e45423ba/fbs/_defaults/src/build/settings/base.json#L20


Example of some of the errors is below. I had more but i had to reboot and forgot to save the actual output as i saved the fixes in my version.

nmcli requires python 3.7 which would totally works if you patch 0.9.x or use fbs_pro(which ive paid for ) but docker previously was hardcoded to python3 or 3.6 for all these distros
```
  Downloading fbs-0.9.2.tar.gz (202 kB)
ERROR: Could not find a version that satisfies the requirement nmcli
ERROR: No matching distribution found for nmcli

The command '/bin/sh -c pip install --upgrade pip && pip install -r "/tmp/requirements/${requirements}"' returned a non-zero code: 1
```


I spliced the above fixes in and left comments in there with links which you can feel free to remove if undesired after reviewing the  below.

basically this awesome concept I implemented directly into these docker files so there all uniform minus the OS specific packages and quirks.
https://github.com/tzenderman/docker-pyenv

I stumbled onto that approach from looking at some of these links.
https://dev.to/javidjms/stop-using-virtualenv-pyenv-nvm-goenv-and-use-docker-images-40mn
https://levelup.gitconnected.com/docker-multi-stage-builds-and-copy-from-other-images-3bf1a2b095e0

I think the proposed method supplied is the lightest way to implement without additional dependencies and potential failure. Feel free to edit as needed if there's something i missed.

More about pyenv
https://github.com/pyenv/pyenv/wiki
