### PR TITLE
Fix bug with `fbs installer` on MacOS Big Sur

### DIFF
--- a/fbs/installer/mac/__init__.py
+++ b/fbs/installer/mac/__init__.py
@@ -22,8 +22,12 @@ def create_installer_mac():
             dest,
             path('${freeze_dir}')
         ]
-        if is_mac() and int(platform.mac_ver()[0].split('.')[1]) >= 15:
-            pdata.insert(1, '--no-internet-enable')
+
+        if is_mac():
+            major, minor, patch = platform.mac_ver()[0].split('.')
+            if (int(major) == 10 and int(minor) >= 15) or int(major) >= 11:
+                pdata.insert(1, '--no-internet-enable')
+
         check_call(pdata, stdout=DEVNULL)
     except:
         if dest_existed:


### PR DESCRIPTION
Fixes `hdiutil: internet-enable: verb not recognized` happening on Big Sur.

Issue reported here (https://github.com/mherrmann/fbs/issues/154) and fixed (https://github.com/mherrmann/fbs/commit/760e831ef81ed25ef8fedff759398fe2371b1618), but did not account for the major version being incremented.
