### PR TITLE
Account for macOS versions without a patch number (ex: 11.3)

### DIFF
--- a/fbs/installer/mac/__init__.py
+++ b/fbs/installer/mac/__init__.py
@@ -24,7 +24,7 @@ def create_installer_mac():
         ]
 
         if is_mac():
-            major, minor, patch = platform.mac_ver()[0].split('.')
+            major, minor = platform.mac_ver()[0].split('.')[:2]
             if (int(major) == 10 and int(minor) >= 15) or int(major) >= 11:
                 pdata.insert(1, '--no-internet-enable')
 


### PR DESCRIPTION
On the version of macOS Big Sur that I am running (11.3), the OS version only has major and minor version components, lacking the patch version found in previous version of macOS (ex: 10.15.0, 10.15.1, etc.). This causes issues during the `fbs freeze` command as shown below:

```bash
Traceback (most recent call last):
  File "/Users/aditya/Development/melbourne/melbourne/py36-venv/bin/fbs", line 11, in <module>
    load_entry_point('fbs==0.9.5', 'console_scripts', 'fbs')()
  File "/Users/aditya/Development/melbourne/melbourne/py36-venv/lib/python3.6/site-packages/fbs/__main__.py", line 17, in _main
    fbs.cmdline.main()
  File "/Users/aditya/Development/melbourne/melbourne/py36-venv/lib/python3.6/site-packages/fbs/cmdline.py", line 32, in main
    fn(*args)
  File "/Users/aditya/Development/melbourne/melbourne/py36-venv/lib/python3.6/site-packages/fbs/builtin_commands/__init__.py", line 183, in installer
    create_installer_mac()
  File "/Users/aditya/Development/melbourne/melbourne/py36-venv/lib/python3.6/site-packages/fbs/installer/mac/__init__.py", line 27, in create_installer_mac
    major, minor, patch = platform.mac_ver()[0].split('.')
ValueError: not enough values to unpack (expected 3, got 2)
```
Taking a look at the offending line in `fbs/installer/mac/__init__.py`, I see that it is only using the values of the major and minor version numbers and ignoring the patch version number. As a result, I've updated the line to just extract the first two components of the split macOS version number which will no longer throw an error when the patch number is not present.