### PR TITLE
Updates windows sign to match sign tool update

### DIFF
--- a/fbs/sign/windows.py
+++ b/fbs/sign/windows.py
@@ -9,33 +9,31 @@ import hashlib
 import json
 import os
 
-_CERTIFICATE_PATH = "src/sign/windows/certificate.pfx"
-_TO_SIGN = (".exe", ".cab", ".dll", ".ocx", ".msi", ".xpi")
-
+_CERTIFICATE_PATH = 'src/sign/windows/certificate.pfx'
+_TO_SIGN = ('.exe', '.cab', '.dll', '.ocx', '.msi', '.xpi')
 
 def sign_windows():
     if not exists(path(_CERTIFICATE_PATH)):
         raise FbsError(
-            "Could not find a code signing certificate at:\n    " + _CERTIFICATE_PATH
+            'Could not find a code signing certificate at:\n    '
+            + _CERTIFICATE_PATH
         )
-    if "windows_sign_pass" not in SETTINGS:
+    if 'windows_sign_pass' not in SETTINGS:
         raise FbsError(
             "Please set 'windows_sign_pass' to the password of %s in either "
             "src/build/settings/secret.json, .../windows.json or .../base.json."
             % _CERTIFICATE_PATH
         )
-    for subdir, _, files in os.walk(path("${freeze_dir}")):
+    for subdir, _, files in os.walk(path('${freeze_dir}')):
         for file_ in files:
             extension = splitext(file_)[1]
             if extension in _TO_SIGN:
                 sign_file(join(subdir, file_))
 
-
-def sign_file(file_path, description="", url=""):
+def sign_file(file_path, description='', url=''):
     helper = _SignHelper.instance()
     if not helper.is_signed(file_path):
         helper.sign(file_path, description, url)
-
 
 class _SignHelper:
 
@@ -44,7 +42,7 @@ class _SignHelper:
     @classmethod
     def instance(cls):
         if cls._INSTANCE is None:
-            cls._INSTANCE = cls(path("cache/signed"))
+            cls._INSTANCE = cls(path('cache/signed'))
         return cls._INSTANCE
 
     def __init__(self, cache_dir):
@@ -52,7 +50,8 @@ class _SignHelper:
 
     def is_signed(self, file_path):
         return not call(
-            ["signtool", "verify", "/pa", file_path], stdout=DEVNULL, stderr=DEVNULL
+            ['signtool', 'verify', '/pa', file_path], stdout=DEVNULL,
+            stderr=DEVNULL
         )
 
     def sign(self, file_path, description, url):
@@ -60,11 +59,9 @@ class _SignHelper:
         try:
             with open(json_path) as f:
                 cached = json.load(f)
-            is_in_cache = (
-                description == cached["description"]
-                and url == cached["url"]
-                and self._hash(file_path) == cached["hash"]
-            )
+            is_in_cache = description == cached['description'] and \
+                          url == cached['url'] and \
+                          self._hash(file_path) == cached['hash']
         except FileNotFoundError:
             is_in_cache = False
         if not is_in_cache:
@@ -77,47 +74,51 @@ class _SignHelper:
         copy(file_path, path_in_cache)
         hash_ = self._hash(path_in_cache)
         self._run_signtool(path_in_cache)
-        with open(self._get_json_path(file_path), "w") as f:
-            json.dump({"description": description, "url": url, "hash": hash_}, f)
+        with open(self._get_json_path(file_path), 'w') as f:
+            json.dump({
+                'description': description,
+                'url': url,
+                'hash': hash_
+            }, f)
 
     def _get_json_path(self, file_path):
-        return self._get_path_in_cache(file_path) + ".json"
+        return self._get_path_in_cache(file_path) + '.json'
 
     def _get_path_in_cache(self, file_path):
         return join(self._cache_dir, basename(file_path))
 
-    def _run_signtool(self, file_path, description="", url=""):
-        password = SETTINGS["windows_sign_pass"]
-        fd = ""
-        td = ""
-        args = ["signtool", "sign", "/f", path(_CERTIFICATE_PATH), "/p", password]
-        if "windows_sign_server" in SETTINGS:
-            args.extend(["/tr", SETTINGS["windows_sign_server"]])
+    def _run_signtool(self, file_path, description='', url=''):
+        password = SETTINGS['windows_sign_pass']
+        fd = ''
+        td = ''
+        args = ['signtool', 'sign', '/f', path(_CERTIFICATE_PATH), '/p', password]
+        if 'windows_sign_server' in SETTINGS:
+            args.extend(['/tr', SETTINGS['windows_sign_server']])
         if description:
-            args.extend(["/d", description])
+            args.extend(['/d', description])
         if url:
-            args.extend(["/du", url])
-        args.append("/as")
-        if "windows_file_digest_algorithm" in SETTINGS:
-            fd = SETTINGS["windows_file_digest_algorithm"]
-        if "windows_timestamp_digest_algorithm" in SETTINGS:
-            td = SETTINGS["windows_timestamp_digest_algorithm"]
-        if fd != "" and td != "":
-            args.extend(["/fd", fd, "/td", td])
+            args.extend(['/du', url])
+        args.append('/as')
+        if 'windows_file_digest_algorithm' in SETTINGS:
+            fd = SETTINGS['windows_file_digest_algorithm']
+        if 'windows_timestamp_digest_algorithm' in SETTINGS:
+            td = SETTINGS['windows_timestamp_digest_algorithm']
+        if fd != '' and td != '':
+            args.extend(['/fd', fd, '/td', td])
             args.append(file_path)
             run(args, check=True, stdout=DEVNULL)
         else:
-            args.extend(["/fd", "sha1", "/td", "sha1"])
+            args.extend(['/fd', 'sha1', '/td', 'sha1'])
             args.append(file_path)
             run(args, check=True, stdout=DEVNULL)
-            args[-2] = "sha256"
-            args[-4] = "sha256"
+            args[-2] = 'sha256'
+            args[-4] = 'sha256'
             run(args, check=True, stdout=DEVNULL)
 
     def _hash(self, file_path):
         bufsize = 65536
         hasher = hashlib.md5()
-        with open(file_path, "rb") as f:
+        with open(file_path, 'rb') as f:
             buf = f.read(bufsize)
             while buf:
                 hasher.update(buf)


### PR DESCRIPTION
As of Windows 10 ADK builds 20236 and later to use the signtool the user must include `/fd` and `/td` arguments as it says [here](https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe). 
This PR modifies the  `_run_signtool` function under `windows.py` to include these arguments. I have also added 2 settings options that can be specified in any of : 
- `src/build/settings/secret.json`,
- `.../windows.json` 
- or `.../base.json`

These settings options are : 
- `windows_file_digest_algorithm`
- `windows_timestamp_digest_algorithm`

This way the user of `fbs` can either specify their desired digest algorithm, or use the default mechanism that will sign with both `sha1` and `sha256`
