### PR TITLE
Fix dead link

### DIFF
--- a/fbs/installer/linux.py
+++ b/fbs/installer/linux.py
@@ -65,7 +65,7 @@ def run_fpm(output_type):
         raise FileNotFoundError(
             "fbs could not find executable 'fpm'. Please install fpm using the "
             "instructions at "
-            "https://fpm.readthedocs.io/en/latest/installing.html."
+            "https://fpm.readthedocs.io/en/latest/installation.html."
         ) from None
 
 def _generate_icons():


### PR DESCRIPTION
This is dead: https://fpm.readthedocs.io/en/latest/installing.html
![Screenshot from 2022-05-17 18-20-54](https://user-images.githubusercontent.com/1596188/168922057-5c93e0b8-856c-48d5-9326-2b332e18c64c.png)


Looks like we want to use this now
https://fpm.readthedocs.io/en/latest/installation.html

Upgraded my OS and noticed the error cause fpm somehow got nuked 