### PR TITLE
Fix `buildvm fedora` "patch command not found

### DIFF
--- a/fbs/_defaults/src/build/docker/fedora/Dockerfile
+++ b/fbs/_defaults/src/build/docker/fedora/Dockerfile
@@ -5,7 +5,7 @@ ARG requirements
 
 ARG python_version=3.6.12
 # List from https://github.com/pyenv/pyenv/wiki#suggested-build-environment:
-ARG python_build_deps="make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel"
+ARG python_build_deps="make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel patch"
 
 RUN dnf -y update && dnf clean all
 


### PR DESCRIPTION
Adds patch package to default args so its not missing for higher python versions for pyenv install command

Original error:
```
@ fbs buildvm fedora;
Sending build context to Docker daemon  30.72kB

Step 1/27 : FROM fmanbuildsystem/fedora:25
25: Pulling from fmanbuildsystem/fedora
Digest: sha256:88c5a6b322aba145c9ed72f89402642a741e488c3bc8cfe1ee1dfcb696c0af37
Status: Image is up to date for fmanbuildsystem/fedora:25
 ---> 9cffd21a45e3
Step 2/27 : ARG requirements
 ---> Using cache
 ---> 299563b8cd42
Step 3/27 : ARG python_version=3.6.12
 ---> Using cache
 ---> 5652f9de8d20
Step 4/27 : ARG python_build_deps="make gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel"
 ---> Using cache
 ---> 1102bceb8a66
Step 5/27 : RUN dnf -y update && dnf clean all
 ---> Using cache
 ---> e444ba346f97
Step 6/27 : RUN dnf install -y curl git
 ---> Using cache
 ---> 77362f07255b
Step 7/27 : ENV PYENV_ROOT /root/.pyenv
 ---> Using cache
 ---> 9ce9cfcfa903
Step 8/27 : ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 ---> Using cache
 ---> afe23efa3ce8
Step 9/27 : RUN curl https://pyenv.run | bash
 ---> Using cache
 ---> a900152b3d77
Step 10/27 : RUN pyenv update
 ---> Using cache
 ---> c087227c15b7
Step 11/27 : RUN dnf install -y findutils
 ---> Using cache
 ---> 6be79a7f9f2c
Step 12/27 : RUN echo $python_build_deps | xargs dnf install -y
 ---> Using cache
 ---> 72371e602136
Step 13/27 : RUN CONFIGURE_OPTS=--enable-shared pyenv install $python_version &&     pyenv global $python_version &&     pyenv rehash
 ---> Running in 5f0ecad763c1
Downloading Python-3.9.7.tar.gz...
-> https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz
Installing Python-3.9.7...
/root/.pyenv/plugins/python-build/bin/python-build: line 1730: patch: command not found

BUILD FAILED (Fedora 25 using python-build 20180424)

Inspect or clean up the working tree at /tmp/python-build.20221125204115.85
Results logged to /tmp/python-build.20221125204115.85.log

Last 10 log lines:
/tmp/python-build.20221125204115.85 /
/tmp/python-build.20221125204115.85/Python-3.9.7 /tmp/python-build.20221125204115.85 /

The command '/bin/sh -c CONFIGURE_OPTS=--enable-shared pyenv install $python_version &&     pyenv global $python_version &&     pyenv rehash' returned a non-zero code: 1
```

After added builds without issue:
```
@ fbs buildvm fedora
Done. You can now execute:
    fbs runvm fedora

```